### PR TITLE
fix(package.json) update devDependencies

### DIFF
--- a/de_DE/package.json
+++ b/de_DE/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/Jason3S/cspell-dicts/blob/master/de_DE/README.md",
   "devDependencies": {
-    "cspell-tools": "^1.4.0"
+    "cspell-tools": "^1.4.2"
   },
   "dependencies": {
     "configstore": "^3.1.0"

--- a/en_GB/package.json
+++ b/en_GB/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/Jason3S/cspell-dicts/blob/master/en_GB/README.md",
   "devDependencies": {
-    "cspell-tools": "^1.4.0"
+    "cspell-tools": "^1.4.2"
   },
   "dependencies": {
     "configstore": "^3.1.0"

--- a/en_US/package.json
+++ b/en_US/package.json
@@ -33,7 +33,7 @@
   },
   "homepage": "https://github.com/Jason3S/cspell-dicts/blob/master/en_US/README.md",
   "devDependencies": {
-    "cspell-tools": "^1.4.0"
+    "cspell-tools": "^1.4.2"
   },
   "dependencies": {
     "configstore": "^3.1.0"

--- a/es_ES/package.json
+++ b/es_ES/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/Jason3S/cspell-dicts/blob/master/es_ES/README.md",
   "devDependencies": {
-    "cspell-tools": "^1.4.0"
+    "cspell-tools": "^1.4.2"
   },
   "dependencies": {
     "configstore": "^3.1.0"

--- a/fr_FR/package.json
+++ b/fr_FR/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/Jason3S/cspell-dicts/blob/master/fr_FR/README.md",
   "devDependencies": {
-    "cspell-tools": "^1.4.0"
+    "cspell-tools": "^1.4.2"
   },
   "dependencies": {
     "configstore": "^3.1.0"

--- a/golang/package.json
+++ b/golang/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/Jason3S/cspell-dicts/blob/master/golang/README.md",
   "devDependencies": {
-    "cspell-tools": "^1.4.0"
+    "cspell-tools": "^1.4.2"
   },
   "files": [
     "go.txt.gz",

--- a/html-symbol-entities/package.json
+++ b/html-symbol-entities/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/Jason3S/cspell-dicts/blob/master/html-symbol-entities/README.md",
   "devDependencies": {
-    "cspell-tools": "^1.4.0"
+    "cspell-tools": "^1.4.2"
   },
   "dependencies": {
     "configstore": "^3.1.0"

--- a/nl_NL/package.json
+++ b/nl_NL/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/Jason3S/cspell-dicts/blob/master/nl_NL/README.md",
   "devDependencies": {
-    "cspell-tools": "^1.4.0"
+    "cspell-tools": "^1.4.2"
   },
   "dependencies": {
     "configstore": "^3.1.0"

--- a/php/package.json
+++ b/php/package.json
@@ -7,7 +7,7 @@
     "cspell-dict-php-unlink": "./unlink.js"
   },
   "scripts": {
-    "build": "cspell-tools compile \"php.txt\" -o .",
+    "build": "node --max_old_space_size=4096 node_modules/.bin/cspell-tools compile \"php.txt\" -o .",
     "cspell-link": "node install.js",
     "cspell-unlink": "node uninstall.js"
   },
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/Jason3S/cspell-dicts/blob/master/php/README.md",
   "devDependencies": {
-    "cspell-tools": "^1.4.0"
+    "cspell-tools": "^1.4.2"
   },
   "dependencies": {
     "configstore": "^3.1.0"

--- a/pl_PL/package.json
+++ b/pl_PL/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/Jason3S/cspell-dicts/blob/master/pl_PL/README.md",
   "devDependencies": {
-    "cspell-tools": "^1.4.0"
+    "cspell-tools": "^1.4.2"
   },
   "dependencies": {
     "configstore": "^3.1.0"

--- a/pt_BR/package.json
+++ b/pt_BR/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/Jason3S/cspell-dicts/blob/master/pt_BR/README.md",
   "devDependencies": {
-    "cspell-tools": "^1.4.0"
+    "cspell-tools": "^1.4.2"
   },
   "dependencies": {
     "configstore": "^3.1.0"

--- a/pt_PT/package.json
+++ b/pt_PT/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/Jason3S/cspell-dicts/blob/master/pt_PT/README.md",
   "devDependencies": {
-    "cspell-tools": "^1.4.0"
+    "cspell-tools": "^1.4.2"
   },
   "dependencies": {
     "configstore": "^3.1.0"

--- a/python/package.json
+++ b/python/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/Jason3S/cspell-dicts/blob/master/python/README.md",
   "devDependencies": {
-    "cspell-tools": "^1.4.0"
+    "cspell-tools": "^1.4.2"
   },
   "files": [
     "python.txt.gz"

--- a/ru_RU/package.json
+++ b/ru_RU/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/Jason3S/cspell-dicts/blob/master/ru_RU/README.md",
   "devDependencies": {
-    "cspell-tools": "^1.4.0"
+    "cspell-tools": "^1.4.2"
   },
   "dependencies": {
     "configstore": "^3.1.0"

--- a/russian/package.json
+++ b/russian/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/Jason3S/cspell-dicts/blob/master/russian/README.md",
   "devDependencies": {
-    "cspell-tools": "^1.4.0"
+    "cspell-tools": "^1.4.2"
   },
   "dependencies": {
     "configstore": "^3.1.0"

--- a/sv/package.json
+++ b/sv/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/Jason3S/cspell-dicts/blob/master/sv/README.md",
   "devDependencies": {
-    "cspell-tools": "^1.4.0"
+    "cspell-tools": "^1.4.2"
   },
   "dependencies": {
     "configstore": "^3.1.0"


### PR DESCRIPTION
- Update devDependencies to use latest `cspell-tools` version.

Related to:
https://github.com/Jason3S/cspell-dicts/issues/4