### PR TITLE
docs() improve Markdown syntax

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,8 @@
 
 Please feel free to contribute to this project.
 
-How you can contribute:
+## How you can contribute
+
 - Fixing spelling error in dictionaries.
 - Creating new dictionaries.
 - Filing any issues related to using dictionaries.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The [Yeoman](http://yeoman.io/) script can help you create the dictionary templa
 
 Install Yeoman and then link the generator.
 
-```
+```sh
 npm install -g yo
 cd generator-cspell-dicts
 npm link
@@ -50,7 +50,7 @@ cd ..
 
 In the `cspell-dicts` repository root.
 
-```
+```sh
 yo cspell-dicts <name> <path/to/source/words>
 ```
 
@@ -89,6 +89,7 @@ This will add an entry in the cspell global config to import the `cspell-ext.jso
 Use either VS Code or cspell to verify that files spell check correctly.
 
 Remember to unlink when you are done:
+
 ```sh
 npm run unlink
 ```
@@ -104,4 +105,3 @@ npm install -g
 Then run the link command found in the dictionary `README.md` file.  
 It has the following pattern: `cspell-dict-<name>-link`.  
 To unlink: `cspell-dict-<name>-unlink`
-

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -22,6 +22,7 @@ cspell-dict-cpp-unlink
 ## Manual Installation
 
 The `cspell-ext.json` file in this package should be added to the import section in your cspell.json file.
+
 ```javascript
 {
     // …

--- a/de_DE/README.md
+++ b/de_DE/README.md
@@ -22,6 +22,7 @@ cspell-dict-de-de-unlink
 ## Manual Installation
 
 The `cspell-ext.json` file in this package should be added to the import section in your cspell.json file.
+
 ```javascript
 {
     // …

--- a/en_GB/README.md
+++ b/en_GB/README.md
@@ -22,6 +22,7 @@ cspell-dict-en-gb-unlink
 ## Manual Installation
 
 The `cspell-ext.json` file in this package should be added to the import section in your cspell.json file.
+
 ```javascript
 {
     // …

--- a/en_US/README.md
+++ b/en_US/README.md
@@ -5,6 +5,7 @@ English dictionary for cspell.
 This is a pre-built dictionary for use with cspell.
 
 ## Note
+
 This dictionary comes pre-installed with cspell. It should not be necessary to add it.
 
 ## Installation
@@ -25,6 +26,7 @@ cspell-dict-en-us-unlink
 ## Manual Installation
 
 The `cspell-ext.json` file in this package should be added to the import section in your cspell.json file.
+
 ```javascript
 {
     // …

--- a/es_ES/README.md
+++ b/es_ES/README.md
@@ -22,6 +22,7 @@ cspell-dict-es-es-unlink
 ## Manual Installation
 
 The `cspell-ext.json` file in this package should be added to the import section in your cspell.json file.
+
 ```javascript
 {
     // …

--- a/fr_FR/README.md
+++ b/fr_FR/README.md
@@ -22,6 +22,7 @@ cspell-dict-fr-fr-unlink
 ## Manual Installation
 
 The `cspell-ext.json` file in this package should be added to the import section in your cspell.json file.
+
 ```javascript
 {
     // …

--- a/generator-cspell-dicts/README.md
+++ b/generator-cspell-dicts/README.md
@@ -1,4 +1,5 @@
 # generator-cspell-dicts
+
 Generate cspell dictionary sub-projects.
 
 ## Installation
@@ -12,7 +13,8 @@ npm link
 
 Then generate a dictionary project:
 
-Exmaple for **monkey** language:
+Example for **monkey** language:
+
 ```bash
 mkdir monkey
 yo cspell-dicts
@@ -21,13 +23,11 @@ yo cspell-dicts
 
 ## Getting To Know Yeoman
 
- * Yeoman has a heart of gold.
- * Yeoman is a person with feelings and opinions, but is very easy to work with.
- * Yeoman can be too opinionated at times but is easily convinced not to be.
- * Feel free to [learn more about Yeoman](http://yeoman.io/).
+* Yeoman has a heart of gold.
+* Yeoman is a person with feelings and opinions, but is very easy to work with.
+* Yeoman can be too opinionated at times but is easily convinced not to be.
+* Feel free to [learn more about Yeoman](http://yeoman.io/).
 
 ## License
 
-MIT © [Jason Dent]()
-
-
+MIT © Jason Dent

--- a/generator-cspell-dicts/generators/app/templates/README.md
+++ b/generator-cspell-dicts/generators/app/templates/README.md
@@ -22,6 +22,7 @@ npm install -g <%= fullPackageName %>
 ## Manual Installation
 
 The `cspell-ext.json` file in this package should be added to the import section in your cspell.json file.
+
 ```javascript
 {
     // …

--- a/golang/README.md
+++ b/golang/README.md
@@ -5,6 +5,7 @@ This is a pre-built dictionary for use with cspell.
 ## Usage
 
 The `cspell-ext.json` file in this package should be added to the import section in your cspell.json file.
+
 ```json
 {
     // …

--- a/html-symbol-entities/README.md
+++ b/html-symbol-entities/README.md
@@ -25,6 +25,7 @@ cspell-dict-html-symbol-entities-unlink
 ## Manual Installation
 
 The `cspell-ext.json` file in this package should be added to the import section in your `cspell.json` file.
+
 ```javascript
 {
     // …

--- a/nl_NL/README.md
+++ b/nl_NL/README.md
@@ -22,6 +22,7 @@ cspell-dict-nl-nl-unlink
 ## Manual Installation
 
 The `cspell-ext.json` file in this package should be added to the import section in your cspell.json file.
+
 ```javascript
 {
     // …

--- a/php/README.md
+++ b/php/README.md
@@ -22,6 +22,7 @@ cspell-dict-php-unlink
 ## Manual Installation
 
 The `cspell-ext.json` file in this package should be added to the import section in your cspell.json file.
+
 ```json
 {
     // …

--- a/pl_PL/README.md
+++ b/pl_PL/README.md
@@ -22,6 +22,7 @@ cspell-dict-pl-pl-unlink
 ## Manual Installation
 
 The `cspell-ext.json` file in this package should be added to the import section in your cspell.json file.
+
 ```javascript
 {
     // …

--- a/pt_BR/README.md
+++ b/pt_BR/README.md
@@ -22,6 +22,7 @@ cspell-dict-pt-br-unlink
 ## Manual Installation
 
 The `cspell-ext.json` file in this package should be added to the import section in your cspell.json file.
+
 ```javascript
 {
     // …

--- a/pt_PT/README.md
+++ b/pt_PT/README.md
@@ -22,6 +22,7 @@ cspell-dict-pt-pt-unlink
 ## Manual Installation
 
 The `cspell-ext.json` file in this package should be added to the import section in your cspell.json file.
+
 ```javascript
 {
     // …

--- a/ru_RU/README.md
+++ b/ru_RU/README.md
@@ -22,6 +22,7 @@ cspell-dict-ru-ru-unlink
 ## Manual Installation
 
 The `cspell-ext.json` file in this package should be added to the import section in your cspell.json file.
+
 ```javascript
 {
     // …

--- a/russian/README.md
+++ b/russian/README.md
@@ -23,6 +23,7 @@ cspell-dict-russian-unlink
 ## Manual Installation
 
 The `cspell-ext.json` file in this package should be added to the import section in your cspell.json file.
+
 ```javascript
 {
     // …

--- a/sv/README.md
+++ b/sv/README.md
@@ -22,6 +22,7 @@ cspell-dict-sv-unlink
 ## Manual Installation
 
 The `cspell-ext.json` file in this package should be added to the import section in your cspell.json file.
+
 ```javascript
 {
     // …


### PR DESCRIPTION
- Fix Markdown syntax issues from [markdownlint](https://github.com/DavidAnson/markdownlint)
- Improve generator template for `README.md` files.

### Detailed list of errors

MD006 - Consider starting bulleted lists at the beginning of the line
MD012 - Multiple consecutive blank lines
MD022 - Headers should be surrounded by blank lines
MD031 - Fenced code blocks should be surrounded by blank lines
MD032 - Lists should be surrounded by blank lines
MD040 - Fenced code blocks should have a language specified
MD042 - No empty links

### More details

- https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md