### PR TITLE
fix(scripts) add missing quotes

### DIFF
--- a/scripts/publish_dict.sh
+++ b/scripts/publish_dict.sh
@@ -1,3 +1,5 @@
-echo Publish $1
-cd $1 && npm run publish-patch
+#!/bin/bash
+
+echo "Publish $1"
+cd "$1" && npm run publish-patch
 echo Done.

--- a/scripts/publish_langs.sh
+++ b/scripts/publish_langs.sh
@@ -16,6 +16,6 @@ fi
 
 for i in "${dictionaries[@]}"
 do
-    echo Running: ./scripts/publish_dict.sh $i
-    ./scripts/publish_dict.sh $i
+    echo "Running: ./scripts/publish_dict.sh $i"
+    ./scripts/publish_dict.sh "$i"
 done


### PR DESCRIPTION
- Add missing quotes to the scripts to avoid errors
- Add missing shell command to the top of `publish_dict.sh`

Improve code quality by checking the scripts with [ShellCheck](https://github.com/koalaman/shellcheck)

These issues should be fixed with this Git commit:
```
In publish_dict.sh line 1:
echo Publish $1
^-- SC2148: Tips depend on target shell and yours is unknown. Add a shebang.
             ^-- SC2086: Double quote to prevent globbing and word splitting.

In publish_dict.sh line 2:
cd $1 && npm run publish-patch
   ^-- SC2086: Double quote to prevent globbing and word splitting.

In publish_langs.sh line 19:
    echo Running: ./scripts/publish_dict.sh $i
                                            ^-- SC2086: Double quote to prevent globbing and word splitting.

In publish_langs.sh line 20:
    ./scripts/publish_dict.sh $i
                              ^-- SC2086: Double quote to prevent globbing and word splitting.
```