### PR TITLE
fix(generator): update outdated package.json

### DIFF
--- a/generator-cspell-dicts/package.json
+++ b/generator-cspell-dicts/package.json
@@ -21,8 +21,7 @@
     "eslint": "^5.0.0",
     "eslint-config-xo-space": "^0.18.0",
     "jest": "^23.1.0",
-    "jest-cli": "^23.1.0",
-    "nsp": "^3.2.1",
+    "jest-cli": "^23.6.0",
     "yeoman-assert": "^3.1.1",
     "yeoman-test": "^1.7.2"
   },
@@ -36,7 +35,7 @@
     "testEnvironment": "node"
   },
   "scripts": {
-    "prepublish": "nsp check",
+    "prepublish": "npm audit",
     "pretest": "eslint . --fix",
     "test": "jest"
   },


### PR DESCRIPTION
- Update outdated `package.json`
- Update outdated Jest version
- Changed from `nsp check` to `npm audit`
- Remove `nsp` from `devDependencies`

Related to:
- https://github.com/Jason3S/cspell-dicts/issues/39