### PR TITLE
Add Ghent University

### DIFF
--- a/packages/companies/companies.txt
+++ b/packages/companies/companies.txt
@@ -367,6 +367,7 @@ Genuine Parts Company
 Genworth Financial, Inc.
 George Weston
 GeoTrust Global
+Ghent University
 Gilead Sciences, Inc.
 GlaxoSmithKline
 Glencore International
@@ -908,6 +909,7 @@ U.S. Bancorp
 U.S. Postal Service
 Uber
 UBS
+UGent
 UGI Corporation
 Ultrapar Holdings
 UniCredit Group
@@ -925,6 +927,7 @@ United Technologies
 United Technologies
 UnitedHealth Group
 Universal Health Services, Inc.
+Universiteit Gent
 Unum Group
 URS Corporation
 US Foods, Inc.


### PR DESCRIPTION
These are the three official ways to write the name of Ghent University (https://www.ugent.be/)

(moved here from https://github.com/Jason3S/cspell/pull/76)